### PR TITLE
Limit the `dist` folder to being the only thing published to NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "medal-js",
   "description": "JavaScript library for the Medal.tv API",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "dist/index.js",
   "repository": "https://github.com/pqt/medal-js",
   "author": "Austin Paquette <austin.paquette@forcir.com>",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "test": "jest --passWithNoTests",
     "prepublishOnly": "npm run build"
   },
+  "files": [
+    "dist/"
+  ],
   "dependencies": {
     "axios": "^0.21.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "medal-js",
   "description": "JavaScript library for the Medal.tv API",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "dist/index.js",
   "repository": "https://github.com/pqt/medal-js",
   "author": "Austin Paquette <austin.paquette@forcir.com>",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "medal-js",
   "description": "JavaScript library for the Medal.tv API",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "dist/index.js",
   "repository": "https://github.com/pqt/medal-js",
   "author": "Austin Paquette <austin.paquette@forcir.com>",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,11 @@
 import axios, { AxiosInstance } from 'axios';
-import { configureOptions } from './options';
+
+const configureOptions = (options: MedalAPI.LatestOptions | MedalAPI.SearchOptions | MedalAPI.TrendingOptions) => {
+  return {
+    ...options,
+    customStyleClass: options.customStyleClass ? options.customStyleClass.concat(' medal-js') : 'medal-js',
+  };
+};
 
 export class Medal {
   #api: AxiosInstance;

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,8 +1,0 @@
-export const configureOptions = (
-  options: MedalAPI.LatestOptions | MedalAPI.SearchOptions | MedalAPI.TrendingOptions
-) => {
-  return {
-    ...options,
-    customStyleClass: options.customStyleClass ? options.customStyleClass.concat(' medal-js') : 'medal-js',
-  };
-};


### PR DESCRIPTION
Publishing will also include the package manifest, readme, and license as well.